### PR TITLE
Explicitly import CoreFoundation

### DIFF
--- a/Sources/SwLibTidy/SwLibTidyBufferProtocol.swift
+++ b/Sources/SwLibTidy/SwLibTidyBufferProtocol.swift
@@ -14,6 +14,7 @@
  */
 
 import Foundation
+import CoreFoundation
 import CLibTidy
 
 


### PR DESCRIPTION
On Apple platforms, Foundation re-exports CoreFoundation, which means that doing `import Foundation` also includes the symbols for CoreFoundation. On Linux, this is not the case.

Therefore, compiling SwLibTidy on Linux fails compilation with errors like:

```
cannot find 'CFStringEncodings' in scope
```

and 

```
cannot find 'CFStringConvertEncodingToNSStringEncoding' in scope
```

unless you explicitly import CoreFoundation.